### PR TITLE
feat: dashboard aggregation apis (summary/trend/distribution/top)

### DIFF
--- a/backend/src/main/java/com/experimentalassistant/backend/controller/DashboardController.java
+++ b/backend/src/main/java/com/experimentalassistant/backend/controller/DashboardController.java
@@ -1,0 +1,56 @@
+package com.experimentalassistant.backend.controller;
+
+import com.experimentalassistant.backend.common.Result;
+import com.experimentalassistant.backend.dto.*;
+import com.experimentalassistant.backend.service.DashboardService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/dashboard")
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    public DashboardController(DashboardService dashboardService) {
+        this.dashboardService = dashboardService;
+    }
+
+    @GetMapping("/summary")
+    public Result<DashboardSummaryResponse> summary(DashboardFilter filter) {
+        try {
+            return Result.success(dashboardService.getSummary(filter));
+        } catch (Exception e) {
+            return Result.error(e.getMessage());
+        }
+    }
+
+    @GetMapping("/trend")
+    public Result<List<DashboardTrendPoint>> trend(DashboardFilter filter) {
+        try {
+            return Result.success(dashboardService.getTrend(filter));
+        } catch (Exception e) {
+            return Result.error(e.getMessage());
+        }
+    }
+
+    @GetMapping("/distribution")
+    public Result<List<DashboardDistributionItem>> distribution(DashboardFilter filter, @RequestParam(name = "by") String by) {
+        try {
+            filter.setDistributionBy(by);
+            return Result.success(dashboardService.getDistribution(filter));
+        } catch (Exception e) {
+            return Result.error(e.getMessage());
+        }
+    }
+
+    @GetMapping("/top")
+    public Result<List<DashboardTopRun>> top(DashboardFilter filter) {
+        try {
+            return Result.success(dashboardService.getTop(filter));
+        } catch (Exception e) {
+            return Result.error(e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/experimentalassistant/backend/dto/DashboardDistributionItem.java
+++ b/backend/src/main/java/com/experimentalassistant/backend/dto/DashboardDistributionItem.java
@@ -1,0 +1,9 @@
+package com.experimentalassistant.backend.dto;
+
+import lombok.Data;
+
+@Data
+public class DashboardDistributionItem {
+    private String name;
+    private Long value;
+}

--- a/backend/src/main/java/com/experimentalassistant/backend/dto/DashboardFilter.java
+++ b/backend/src/main/java/com/experimentalassistant/backend/dto/DashboardFilter.java
@@ -1,0 +1,19 @@
+package com.experimentalassistant.backend.dto;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class DashboardFilter {
+    private Long projectId;
+    private String dateFrom;
+    private String dateTo;
+    private String status;
+    private List<Long> tagIds;
+
+    private Long metricDefId;
+    private String direction;
+    private String granularity;
+    private String distributionBy;
+    private Integer limit;
+}

--- a/backend/src/main/java/com/experimentalassistant/backend/dto/DashboardStatsResult.java
+++ b/backend/src/main/java/com/experimentalassistant/backend/dto/DashboardStatsResult.java
@@ -1,0 +1,10 @@
+package com.experimentalassistant.backend.dto;
+
+import lombok.Data;
+
+@Data
+public class DashboardStatsResult {
+    private Long totalRuns;
+    private Long runsLast7Days;
+    private Long finishedRuns;
+}

--- a/backend/src/main/java/com/experimentalassistant/backend/dto/DashboardSummaryResponse.java
+++ b/backend/src/main/java/com/experimentalassistant/backend/dto/DashboardSummaryResponse.java
@@ -1,0 +1,19 @@
+package com.experimentalassistant.backend.dto;
+
+import lombok.Data;
+
+@Data
+public class DashboardSummaryResponse {
+    private Long totalRuns;
+    private Long runsLast7Days;
+    private Double successRate;
+    private BestMetric bestMetric;
+
+    @Data
+    public static class BestMetric {
+        private Long metricDefId;
+        private String metricName;
+        private Double value;
+        private Long runId;
+    }
+}

--- a/backend/src/main/java/com/experimentalassistant/backend/dto/DashboardTopRun.java
+++ b/backend/src/main/java/com/experimentalassistant/backend/dto/DashboardTopRun.java
@@ -1,0 +1,15 @@
+package com.experimentalassistant.backend.dto;
+
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+public class DashboardTopRun {
+    private Long runId;
+    private String runName;
+    private String modelName;
+    private String datasetName;
+    private Double value;
+    private LocalDateTime createdAt;
+    private String status;
+}

--- a/backend/src/main/java/com/experimentalassistant/backend/dto/DashboardTrendPoint.java
+++ b/backend/src/main/java/com/experimentalassistant/backend/dto/DashboardTrendPoint.java
@@ -1,0 +1,9 @@
+package com.experimentalassistant.backend.dto;
+
+import lombok.Data;
+
+@Data
+public class DashboardTrendPoint {
+    private String x;
+    private Double y;
+}

--- a/backend/src/main/java/com/experimentalassistant/backend/mapper/DashboardMapper.java
+++ b/backend/src/main/java/com/experimentalassistant/backend/mapper/DashboardMapper.java
@@ -1,0 +1,19 @@
+package com.experimentalassistant.backend.mapper;
+
+import com.experimentalassistant.backend.dto.*;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import java.util.List;
+
+@Mapper
+public interface DashboardMapper {
+    DashboardStatsResult getSummaryStats(@Param("filter") DashboardFilter filter);
+
+    DashboardSummaryResponse.BestMetric getBestMetric(@Param("filter") DashboardFilter filter);
+
+    List<DashboardTrendPoint> getTrend(@Param("filter") DashboardFilter filter);
+
+    List<DashboardDistributionItem> getDistribution(@Param("filter") DashboardFilter filter);
+
+    List<DashboardTopRun> getTopRuns(@Param("filter") DashboardFilter filter);
+}

--- a/backend/src/main/java/com/experimentalassistant/backend/service/DashboardService.java
+++ b/backend/src/main/java/com/experimentalassistant/backend/service/DashboardService.java
@@ -1,0 +1,11 @@
+package com.experimentalassistant.backend.service;
+
+import com.experimentalassistant.backend.dto.*;
+import java.util.List;
+
+public interface DashboardService {
+    DashboardSummaryResponse getSummary(DashboardFilter filter);
+    List<DashboardTrendPoint> getTrend(DashboardFilter filter);
+    List<DashboardDistributionItem> getDistribution(DashboardFilter filter);
+    List<DashboardTopRun> getTop(DashboardFilter filter);
+}

--- a/backend/src/main/java/com/experimentalassistant/backend/service/impl/DashboardServiceImpl.java
+++ b/backend/src/main/java/com/experimentalassistant/backend/service/impl/DashboardServiceImpl.java
@@ -1,0 +1,95 @@
+package com.experimentalassistant.backend.service.impl;
+
+import com.experimentalassistant.backend.dto.*;
+import com.experimentalassistant.backend.entity.MetricDef;
+import com.experimentalassistant.backend.mapper.DashboardMapper;
+import com.experimentalassistant.backend.mapper.MetricDefMapper;
+import com.experimentalassistant.backend.service.DashboardService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class DashboardServiceImpl implements DashboardService {
+
+    private final DashboardMapper dashboardMapper;
+    private final MetricDefMapper metricDefMapper;
+
+    public DashboardServiceImpl(DashboardMapper dashboardMapper, MetricDefMapper metricDefMapper) {
+        this.dashboardMapper = dashboardMapper;
+        this.metricDefMapper = metricDefMapper;
+    }
+
+    @Override
+    public DashboardSummaryResponse getSummary(DashboardFilter filter) {
+        ensureProjectId(filter);
+
+        DashboardStatsResult stats = dashboardMapper.getSummaryStats(filter);
+        if (stats == null) {
+            stats = new DashboardStatsResult();
+            stats.setTotalRuns(0L);
+            stats.setRunsLast7Days(0L);
+            stats.setFinishedRuns(0L);
+        }
+
+        long totalRuns = stats.getTotalRuns() == null ? 0L : stats.getTotalRuns();
+        long runsLast7Days = stats.getRunsLast7Days() == null ? 0L : stats.getRunsLast7Days();
+        long finishedRuns = stats.getFinishedRuns() == null ? 0L : stats.getFinishedRuns();
+
+        DashboardSummaryResponse response = new DashboardSummaryResponse();
+        response.setTotalRuns(totalRuns);
+        response.setRunsLast7Days(runsLast7Days);
+
+        if (totalRuns > 0) {
+            double successRate = (double) finishedRuns / totalRuns;
+            response.setSuccessRate(successRate);
+        } else {
+            response.setSuccessRate(0.0);
+        }
+
+        DashboardSummaryResponse.BestMetric bestMetric = dashboardMapper.getBestMetric(filter);
+        response.setBestMetric(bestMetric);
+
+        return response;
+    }
+
+    @Override
+    public List<DashboardTrendPoint> getTrend(DashboardFilter filter) {
+        ensureProjectId(filter);
+        ensureMetricInfo(filter);
+        return dashboardMapper.getTrend(filter);
+    }
+
+    @Override
+    public List<DashboardDistributionItem> getDistribution(DashboardFilter filter) {
+        ensureProjectId(filter);
+        return dashboardMapper.getDistribution(filter);
+    }
+
+    @Override
+    public List<DashboardTopRun> getTop(DashboardFilter filter) {
+        ensureProjectId(filter);
+        ensureMetricInfo(filter);
+        if (filter.getLimit() == null) {
+            filter.setLimit(10);
+        }
+        return dashboardMapper.getTopRuns(filter);
+    }
+
+    private void ensureProjectId(DashboardFilter filter) {
+        if (filter.getProjectId() == null) {
+            throw new IllegalArgumentException("Project ID is required");
+        }
+    }
+
+    private void ensureMetricInfo(DashboardFilter filter) {
+        if (filter.getMetricDefId() == null) {
+            throw new IllegalArgumentException("Metric Definition ID is required");
+        }
+        MetricDef metricDef = metricDefMapper.selectById(filter.getMetricDefId());
+        if (metricDef == null) {
+            throw new IllegalArgumentException("Invalid Metric Definition ID: " + filter.getMetricDefId());
+        }
+        filter.setDirection(metricDef.getDirection());
+    }
+}

--- a/backend/src/main/resources/mapper/DashboardMapper.xml
+++ b/backend/src/main/resources/mapper/DashboardMapper.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.experimentalassistant.backend.mapper.DashboardMapper">
+
+    <sql id="commonWhere">
+        <where>
+            r.project_id = #{filter.projectId}
+            <if test="filter.dateFrom != null and filter.dateFrom != ''">
+                AND r.created_at &gt;= #{filter.dateFrom}
+            </if>
+            <if test="filter.dateTo != null and filter.dateTo != ''">
+                AND r.created_at &lt;= CONCAT(#{filter.dateTo}, ' 23:59:59')
+            </if>
+            <if test="filter.status != null and filter.status != ''">
+                AND r.status = #{filter.status}
+            </if>
+            <if test="filter.tagIds != null and filter.tagIds.size() > 0">
+                AND EXISTS (
+                    SELECT 1 FROM run_tag rt_filter
+                    WHERE rt_filter.run_id = r.id
+                    AND rt_filter.tag_id IN
+                    <foreach item="tagId" collection="filter.tagIds" open="(" separator="," close=")">
+                        #{tagId}
+                    </foreach>
+                )
+            </if>
+        </where>
+    </sql>
+
+    <select id="getSummaryStats" resultType="com.experimentalassistant.backend.dto.DashboardStatsResult">
+        SELECT
+            COUNT(*) as totalRuns,
+            SUM(CASE WHEN r.created_at >= DATE_SUB(CURDATE(), INTERVAL 6 DAY) THEN 1 ELSE 0 END) as runsLast7Days,
+            SUM(CASE WHEN r.status = 'FINISHED' THEN 1 ELSE 0 END) as finishedRuns
+        FROM run r
+        <include refid="commonWhere"/>
+    </select>
+
+    <select id="getBestMetric" resultType="com.experimentalassistant.backend.dto.DashboardSummaryResponse$BestMetric">
+        SELECT
+            rm.metric_def_id as metricDefId,
+            md.name as metricName,
+            rm.value as value,
+            r.id as runId
+        FROM run r
+        JOIN run_metric rm ON r.id = rm.run_id
+        JOIN metric_def md ON rm.metric_def_id = md.id
+        <include refid="commonWhere"/>
+        ORDER BY
+            CASE WHEN md.direction = 'MAX' THEN rm.value ELSE -rm.value END DESC
+        LIMIT 1
+    </select>
+
+    <select id="getTrend" resultType="com.experimentalassistant.backend.dto.DashboardTrendPoint">
+        SELECT
+            DATE_FORMAT(r.created_at, '%Y-%m-%d') as x,
+            <choose>
+                <when test="filter.direction == 'MAX'">MAX(rm.value)</when>
+                <otherwise>MIN(rm.value)</otherwise>
+            </choose> as y
+        FROM run r
+        JOIN run_metric rm ON r.id = rm.run_id
+        <include refid="commonWhere"/>
+        AND rm.metric_def_id = #{filter.metricDefId}
+        GROUP BY DATE_FORMAT(r.created_at, '%Y-%m-%d')
+        ORDER BY x ASC
+    </select>
+
+    <select id="getDistribution" resultType="com.experimentalassistant.backend.dto.DashboardDistributionItem">
+        <choose>
+            <when test="filter.distributionBy == 'tag'">
+                SELECT
+                    t.name as name,
+                    COUNT(DISTINCT r.id) as value
+                FROM run r
+                JOIN run_tag rt ON r.id = rt.run_id
+                JOIN tag t ON rt.tag_id = t.id
+                <include refid="commonWhere"/>
+                GROUP BY t.name
+            </when>
+            <when test="filter.distributionBy == 'model'">
+                SELECT
+                    IFNULL(r.model_name, 'Unknown') as name,
+                    COUNT(*) as value
+                FROM run r
+                <include refid="commonWhere"/>
+                GROUP BY r.model_name
+            </when>
+            <when test="filter.distributionBy == 'dataset'">
+                SELECT
+                    IFNULL(r.dataset_name, 'Unknown') as name,
+                    COUNT(*) as value
+                FROM run r
+                <include refid="commonWhere"/>
+                GROUP BY r.dataset_name
+            </when>
+        </choose>
+    </select>
+
+    <select id="getTopRuns" resultType="com.experimentalassistant.backend.dto.DashboardTopRun">
+        SELECT
+            r.id as runId,
+            r.name as runName,
+            r.model_name as modelName,
+            r.dataset_name as datasetName,
+            rm.value as value,
+            r.created_at as createdAt,
+            r.status as status
+        FROM run r
+        JOIN run_metric rm ON r.id = rm.run_id
+        <include refid="commonWhere"/>
+        AND rm.metric_def_id = #{filter.metricDefId}
+        ORDER BY
+        <choose>
+            <when test="filter.direction == 'MAX'">rm.value DESC</when>
+            <otherwise>rm.value ASC</otherwise>
+        </choose>
+        LIMIT #{filter.limit}
+    </select>
+
+</mapper>


### PR DESCRIPTION
- Add /api/dashboard summary trend distribution top endpoints

- Implement aggregation queries via DashboardMapper custom SQL

- Support filters: projectId dateFrom dateTo status tagIds

- Implement best-of-day trend based on metric_def.direction

- Add top runs sorting by metric direction